### PR TITLE
Adding the ability to unstack based on a specific column

### DIFF
--- a/superset/assets/src/explore/controlPanels/PivotTable.js
+++ b/superset/assets/src/explore/controlPanels/PivotTable.js
@@ -36,6 +36,7 @@ export default {
       controlSetRows: [
         ['pandas_aggfunc', 'pivot_margins'],
         ['number_format', 'combine_metric'],
+        ['unstacked_column', 'unstacked_na_value'],
       ],
     },
   ],

--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -1361,6 +1361,26 @@ export const controls = {
     'computing the total rows and columns'),
   },
 
+  unstacked_column: {
+    type: 'SelectControl',
+    label: t('Unstacked column'),
+    clearable: true,
+    renderTrigger: true,
+    default: '',
+    description: t('Name of the column to be unstacked'),
+    mapStateToProps: state => ({
+      choices: columnChoices(state.datasource),
+    }),
+  },
+
+  unstacked_na_value: {
+    type: 'TextControl',
+    label: t('Unstacked N/A value'),
+    renderTrigger: true,
+    default: '0',
+    description: t('The value to be used for NULL(N/A) cells'),
+  },
+
   js_agg_function: {
     type: 'SelectControl',
     label: t('Dynamic Aggregation Function'),


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This commit will add a UI feature to support unstacking functionality for Pivot Tables.
This feature also needs changes in `viz.py` to take care of newly added fields(`unstacked_column` and `unstacked_na_value`)'s values to be marked as completed for further use.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
<img width="491" alt="Screen Shot 2019-05-21 at 6 50 11 PM" src="https://user-images.githubusercontent.com/3028216/58104159-8af69600-7bf9-11e9-9d65-8227db9654e3.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->
Two new controls(one SelectControl and one TextControl) is expected to be added in Pivot Options section.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
